### PR TITLE
Fix tooltips

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2637,6 +2637,15 @@
         "object-assign": "^4.1.1"
       }
     },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4630,6 +4639,11 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
       "version": "4.2.0",
@@ -8979,6 +8993,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-popper": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
+      "integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
+    },
     "react-test-renderer": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
@@ -10714,6 +10741,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,6 @@
     "build": "npm test && npm run prebuild && shadow-cljs release dist --source-maps"
   },
   "dependencies": {
-    "@material-ui/core": "4.0.1",
     "create-react-class": "^15.6.3",
     "diff-dom": "^4.1.6",
     "react": "^16.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
     "diff-dom": "^4.1.6",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-popper": "^1.3.4",
     "sax": "^1.2.4"
   },
   "main": "dist/mule_preview.client.js_export.js"

--- a/client/public/css/plugin.css
+++ b/client/public/css/plugin.css
@@ -250,31 +250,34 @@
 
 /* Tooltip */
 
-.mp .popover-content ul {
+.mp-popover ul {
   list-style-type: none;
   padding-left: 0;
 }
 
-.mp .popover-content .previous {
+.mp-popover .previous {
   color: red;
   text-decoration: line-through;
 }
 
-.mp .popover-content .current {
+.mp-popover .current {
   color: green;
 }
 
 /* Extracted from Bootstrap v3.3.5 stylesheet
    We use re-com for the popovers and it depends on Bootstrap.
    so we don't have to pull in the world for one popover I extracted
-   it manually.
-   See https://github.com/Day8/re-com#using-re-com */
-.mp .popover {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1060;
-  display: none;
+   it manually. */
+
+.mp-popover-root {
+  z-index: 5000;
+}
+
+.mp-popover-root > * {
+  z-index: 5000;
+}
+
+.mp-popover {
   max-width: 276px;
   padding: 1px;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -302,19 +305,19 @@
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   line-break: auto;
 }
-.mp .popover.top {
+.mp-popover.top {
   margin-top: -10px;
 }
-.mp .popover.right {
+.mp-popover.right {
   margin-left: 10px;
 }
-.mp .popover.bottom {
+.mp-popover.bottom {
   margin-top: 10px;
 }
-.mp .popover.left {
+.mp-popover.left {
   margin-left: -10px;
 }
-.mp .popover-title {
+.mp-popover-title {
   padding: 8px 14px;
   margin: 0;
   font-size: 14px;
@@ -322,87 +325,11 @@
   border-bottom: 1px solid #ebebeb;
   border-radius: 5px 5px 0 0;
 }
-.mp .popover-content {
+.mp-popover-content {
   padding: 9px 14px;
 }
-.mp .popover > .arrow,
-.mp .popover > .arrow::after {
-  position: absolute;
-  display: block;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
-}
-.mp .popover > .arrow {
-  border-width: 11px;
-}
-.mp .popover > .arrow::after {
-  content: "";
-  border-width: 10px;
-}
-.mp .popover.top > .arrow {
-  bottom: -11px;
-  left: 50%;
-  margin-left: -11px;
-  border-top-color: #999;
-  border-top-color: rgba(0, 0, 0, 0.25);
-  border-bottom-width: 0;
-}
-.mp .popover.top > .arrow::after {
-  bottom: 1px;
-  margin-left: -10px;
-  content: " ";
-  border-top-color: #fff;
-  border-bottom-width: 0;
-}
-.mp .popover.right > .arrow {
-  top: 50%;
-  left: -11px;
-  margin-top: -11px;
-  border-right-color: #999;
-  border-right-color: rgba(0, 0, 0, 0.25);
-  border-left-width: 0;
-}
-.mp .popover.right > .arrow::after {
-  bottom: -10px;
-  left: 1px;
-  content: " ";
-  border-right-color: #fff;
-  border-left-width: 0;
-}
-.mp .popover.bottom > .arrow {
-  top: -11px;
-  left: 50%;
-  margin-left: -11px;
-  border-top-width: 0;
-  border-bottom-color: #999;
-  border-bottom-color: rgba(0, 0, 0, 0.25);
-}
-.mp .popover.bottom > .arrow::after {
-  top: 1px;
-  margin-left: -10px;
-  content: " ";
-  border-top-width: 0;
-  border-bottom-color: #fff;
-}
-.mp .popover.left > .arrow {
-  top: 50%;
-  right: -11px;
-  margin-top: -11px;
-  border-right-width: 0;
-  border-left-color: #999;
-  border-left-color: rgba(0, 0, 0, 0.25);
-}
-.mp .popover.left > .arrow::after {
-  right: 1px;
-  bottom: -10px;
-  content: " ";
-  border-right-width: 0;
-  border-left-color: #fff;
-}
 
-.mp .change-location {
+.mp-change-location {
   font-size: 0.75rem;
   padding: 0;
   margin: 0;

--- a/client/shadow-cljs.edn
+++ b/client/shadow-cljs.edn
@@ -9,8 +9,7 @@
   [cljs-http "0.1.46"]
   [cheshire "5.8.1"]
   [lambdaisland/uri "1.1.0"]
-  [cider/cider-nrepl "0.21.1"]
-  [re-com "2.5.0"]]
+  [cider/cider-nrepl "0.21.1"]]
 
  :dev-http {8080 "public"}
  :builds

--- a/client/src/main/mule_preview/client/components.cljs
+++ b/client/src/main/mule_preview/client/components.cljs
@@ -2,10 +2,11 @@
   "The react components that render the Mule preview"
   (:require
    [reagent.core :as r]
+   [react-dom :as react-dom]
    [clojure.string :refer [split replace]]
    [mule-preview.client.mappings :refer [element-to-icon-map]]
    [lambdaisland.uri :refer [join]]
-   [re-com.core :refer [popover-content-wrapper popover-anchor-wrapper]])
+   ["react-popper" :refer [Manager Reference Popper]])
   (:require-macros [mule-preview.client.macros :as m]))
 
 (def default-component-mapping {:image "UnknownNode-48x32.png"})
@@ -107,60 +108,68 @@
   [:div "Element Removed"])
 
 (defn tooltip [change-record labels location]
-  [popover-content-wrapper
-   :title (str "Line " (:line location) ", Column " (:column location))
-   :body [:div
-          (cond
-            (:added labels) (tooltip-added)
-            (:removed labels) (tooltip-removed)
-            (:edited labels) (tooltip-edited change-record)
-            :else nil)]])
+  [:div {:class "popover"}
+   [:h3 (str "Line " (:line location) ", Column " (:column location))]
+   [:div
+    (cond
+      (:added labels) (tooltip-added)
+      (:removed labels) (tooltip-removed)
+      (:edited labels) (tooltip-edited change-record)
+      :else nil)]])
+
+(defn popper [showing-atom anchor-el tooltip-element]
+  (when @showing-atom (react-dom/createPortal
+                       (r/as-element [:> Popper {:placement "right" :reference-element @anchor-el}
+                                      (fn [props]
+                                        (let [{:keys [ref style placement]} (js->clj props :keywordize-keys true)]
+                                          (r/as-element [:div {:ref ref :style style :data-placement placement} tooltip-element])))])
+                       (.-body js/document))))
 
 (defn mule-component-inner [{:keys [name description css-class content-root location change-record showing-atom labels]}]
-  (let [img-url (name-to-img-url name false default-component-mapping)
+  (let [anchor-el (clojure.core/atom nil)
+        img-url (name-to-img-url name false default-component-mapping)
         diff-icon-url (labels-to-diff-icon-url labels)
         category-url (name-to-category-url name default-category-image)
-        tooltip (tooltip change-record labels location)
+        tooltip-element (tooltip change-record labels location)
         should-show-tooltip (or change-record (:added labels) (:removed labels))]
-    [popover-anchor-wrapper
-     :position :below-right
-     :showing? showing-atom
-     :popover tooltip
-     :anchor [:div  {:class ["component-container" css-class]
-                     :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
-                     :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
-              (when diff-icon-url (image diff-icon-url "diff-icon" content-root))
-              [:div
-               {:class ["component" name]}
-               (image category-url "category-frame" content-root)
-               (image img-url "icon" content-root)
-               [:div {:class "label"} description]]]]))
+    (fn []
+      [:div {:ref #(reset! anchor-el %)}
+       [:div {:class ["component-container" css-class]
+              :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
+              :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
+        (when diff-icon-url (image diff-icon-url "diff-icon" content-root))
+        [:div
+         {:class ["component" name]}
+         (image category-url "category-frame" content-root)
+         (image img-url "icon" content-root)
+         [:div {:class "label"} description]]]
+       (popper showing-atom anchor-el tooltip-element)])))
 
 (defn mule-component [props]
   (let [showing-atom (r/atom false)]
     (fn [] (mule-component-inner (assoc props :showing-atom showing-atom)))))
 
 (defn mule-container-inner [{:keys [name description children css-class content-root location change-record showing-atom labels]}]
-  (let [generated-css-class (name-to-css-class name)
+  (let [anchor-el (clojure.core/atom nil)
+        generated-css-class (name-to-css-class name)
         img-url (name-to-img-url name (some? children) nil)
         category-url (name-to-category-url name default-category-image)
         interposed-children (interpose (arrow content-root) children)
         child-container-component (child-container interposed-children)
         should-show-tooltip (or change-record (:added labels) (:removed labels))
-        tooltip (tooltip change-record labels location)]
-    [popover-anchor-wrapper
-     :position :below-right
-     :showing? showing-atom
-     :popover tooltip
-     :anchor [:div {:class ["container" generated-css-class css-class]
-                    :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
-                    :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
-              [:div {:class "container-title"} description]
-              [:div {:class "container-inner"}
-               [:div {:class "icon-container"}
-                (image category-url "category-frame" content-root)
-                (image img-url "icon container-image" content-root)]
-               child-container-component]]]))
+        tooltip-element (tooltip change-record labels location)]
+    (fn []
+      [:div {:ref #(reset! anchor-el %)}
+       [:div {:class ["container" generated-css-class css-class]
+              :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
+              :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
+        [:div {:class "container-title"} description]
+        [:div {:class "container-inner"}
+         [:div {:class "icon-container"}
+          (image category-url "category-frame" content-root)
+          (image img-url "icon container-image" content-root)]
+         child-container-component]]
+       (popper showing-atom anchor-el tooltip-element)])))
 
 (defn mule-container [props]
   (let [showing-atom (r/atom false)]

--- a/client/src/main/mule_preview/client/components.cljs
+++ b/client/src/main/mule_preview/client/components.cljs
@@ -107,22 +107,25 @@
 (defn tooltip-removed []
   [:div "Element Removed"])
 
-(defn tooltip [change-record labels location]
-  [:div {:class "popover"}
-   [:h3 (str "Line " (:line location) ", Column " (:column location))]
-   [:div
+(defn tooltip [change-record labels location placement]
+  [:div {:class ["mp-popover" placement]}
+   [:h3 {:class "mp-popover-title"}
+    (str "Line " (:line location) ", Column " (:column location))]
+   [:div {:class "mp-popover-content"}
     (cond
       (:added labels) (tooltip-added)
       (:removed labels) (tooltip-removed)
       (:edited labels) (tooltip-edited change-record)
       :else nil)]])
 
-(defn popper [showing-atom anchor-el tooltip-element]
+(defn popper [change-record labels location showing-atom anchor-el]
   (when @showing-atom (react-dom/createPortal
-                       (r/as-element [:> Popper {:placement "right" :reference-element @anchor-el}
-                                      (fn [props]
-                                        (let [{:keys [ref style placement]} (js->clj props :keywordize-keys true)]
-                                          (r/as-element [:div {:ref ref :style style :data-placement placement} tooltip-element])))])
+                       (r/as-element [:div {:class "mp-popover-root"}
+                                      [:> Popper {:placement "auto" :reference-element @anchor-el}
+                                       (fn [props]
+                                         (let [{:keys [ref style placement]} (js->clj props :keywordize-keys true)]
+                                           (r/as-element [:div {:ref ref :style style :data-placement placement :class placement}
+                                                          (tooltip change-record labels location placement)])))]])
                        (.-body js/document))))
 
 (defn mule-component-inner [{:keys [name description css-class content-root location change-record showing-atom labels]}]
@@ -130,7 +133,6 @@
         img-url (name-to-img-url name false default-component-mapping)
         diff-icon-url (labels-to-diff-icon-url labels)
         category-url (name-to-category-url name default-category-image)
-        tooltip-element (tooltip change-record labels location)
         should-show-tooltip (or change-record (:added labels) (:removed labels))]
     (fn []
       [:div {:ref #(reset! anchor-el %)}
@@ -143,7 +145,7 @@
          (image category-url "category-frame" content-root)
          (image img-url "icon" content-root)
          [:div {:class "label"} description]]]
-       (popper showing-atom anchor-el tooltip-element)])))
+       (popper change-record labels location showing-atom anchor-el)])))
 
 (defn mule-component [props]
   (let [showing-atom (r/atom false)]
@@ -156,8 +158,7 @@
         category-url (name-to-category-url name default-category-image)
         interposed-children (interpose (arrow content-root) children)
         child-container-component (child-container interposed-children)
-        should-show-tooltip (or change-record (:added labels) (:removed labels))
-        tooltip-element (tooltip change-record labels location)]
+        should-show-tooltip (or change-record (:added labels) (:removed labels))]
     (fn []
       [:div {:ref #(reset! anchor-el %)}
        [:div {:class ["container" generated-css-class css-class]
@@ -169,7 +170,7 @@
           (image category-url "category-frame" content-root)
           (image img-url "icon container-image" content-root)]
          child-container-component]]
-       (popper showing-atom anchor-el tooltip-element)])))
+       (popper change-record labels location showing-atom anchor-el)])))
 
 (defn mule-container [props]
   (let [showing-atom (r/atom false)]

--- a/client/src/test/mule_preview/client/__snapshots__/components.spec.js.snap
+++ b/client/src/test/mule_preview/client/__snapshots__/components.spec.js.snap
@@ -1,49 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when rendering a Mule component when the component has mapping renders correctly 1`] = `
-<div
-  className="rc-popover-anchor-wrapper display-inline-flex "
-  style={
-    Object {
-      "WebkitFlex": "inherit",
-      "flex": "inherit",
-    }
-  }
->
+<div>
   <div
-    className="rc-point-wrapper display-inline-flex"
-    style={
-      Object {
-        "WebkitAlignItems": "center",
-        "WebkitFlex": "auto",
-        "WebkitFlexFlow": "column",
-        "alignItems": "center",
-        "flex": "auto",
-        "flexFlow": "column",
-      }
-    }
+    className="component-container some-css-class"
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     <div
-      className="component-container some-css-class"
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      className="component set-payload"
     >
+      <img
+        className="category-frame"
+        src="/img/icons/org.mule.tooling.category.transformers.large.png"
+      />
+      <img
+        className="icon"
+        src="/img/icons/SetPayload-48x32.png"
+      />
       <div
-        className="component set-payload"
+        className="label"
       >
-        <img
-          className="category-frame"
-          src="/img/icons/org.mule.tooling.category.transformers.large.png"
-        />
-        <img
-          className="icon"
-          src="/img/icons/SetPayload-48x32.png"
-        />
-        <div
-          className="label"
-        >
-          Set some payload
-        </div>
+        Set some payload
       </div>
     </div>
   </div>
@@ -51,49 +29,27 @@ exports[`when rendering a Mule component when the component has mapping renders 
 `;
 
 exports[`when rendering a Mule component when the component is unknown renders correctly 1`] = `
-<div
-  className="rc-popover-anchor-wrapper display-inline-flex "
-  style={
-    Object {
-      "WebkitFlex": "inherit",
-      "flex": "inherit",
-    }
-  }
->
+<div>
   <div
-    className="rc-point-wrapper display-inline-flex"
-    style={
-      Object {
-        "WebkitAlignItems": "center",
-        "WebkitFlex": "auto",
-        "WebkitFlexFlow": "column",
-        "alignItems": "center",
-        "flex": "auto",
-        "flexFlow": "column",
-      }
-    }
+    className="component-container some-css-class"
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     <div
-      className="component-container some-css-class"
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      className="component sjdsfjlsdf"
     >
+      <img
+        className="category-frame"
+        src="/img/icons/org.mule.tooling.ui.modules.core.miscellaneous.large.png"
+      />
+      <img
+        className="icon"
+        src="/img/icons/UnknownNode-48x32.png"
+      />
       <div
-        className="component sjdsfjlsdf"
+        className="label"
       >
-        <img
-          className="category-frame"
-          src="/img/icons/org.mule.tooling.ui.modules.core.miscellaneous.large.png"
-        />
-        <img
-          className="icon"
-          src="/img/icons/UnknownNode-48x32.png"
-        />
-        <div
-          className="label"
-        >
-          Set some payload
-        </div>
+        Set some payload
       </div>
     </div>
   </div>
@@ -101,214 +57,126 @@ exports[`when rendering a Mule component when the component is unknown renders c
 `;
 
 exports[`when rendering a Mule container when it has children renders correctly 1`] = `
-<div
-  className="rc-popover-anchor-wrapper display-inline-flex "
-  style={
-    Object {
-      "WebkitFlex": "inherit",
-      "flex": "inherit",
-    }
-  }
->
+<div>
   <div
-    className="rc-point-wrapper display-inline-flex"
-    style={
-      Object {
-        "WebkitAlignItems": "center",
-        "WebkitFlex": "auto",
-        "WebkitFlexFlow": "column",
-        "alignItems": "center",
-        "flex": "auto",
-        "flexFlow": "column",
-      }
-    }
+    className="container mule-flow some-css-class"
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     <div
-      className="container mule-flow some-css-class"
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      className="container-title"
+    >
+      Do something
+    </div>
+    <div
+      className="container-inner"
     >
       <div
-        className="container-title"
+        className="icon-container"
       >
-        Do something
+        <img
+          className="category-frame"
+          src="/img/icons/org.mule.tooling.category.scopes.large.png"
+        />
+        <img
+          className="icon container-image"
+          src="/img/icons/sub-flow-48x32.png"
+        />
       </div>
       <div
-        className="container-inner"
+        className="container-children"
       >
-        <div
-          className="icon-container"
-        >
-          <img
-            className="category-frame"
-            src="/img/icons/org.mule.tooling.category.scopes.large.png"
-          />
-          <img
-            className="icon container-image"
-            src="/img/icons/sub-flow-48x32.png"
-          />
+        <div>
+          <div
+            className="component-container some-css-class"
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+          >
+            <img
+              className="diff-icon"
+              src="/img/is-not-equal-to.svg"
+            />
+            <div
+              className="component set-payload"
+            >
+              <img
+                className="category-frame"
+                src="/img/icons/org.mule.tooling.category.transformers.large.png"
+              />
+              <img
+                className="icon"
+                src="/img/icons/SetPayload-48x32.png"
+              />
+              <div
+                className="label"
+              >
+                Set some payload
+              </div>
+            </div>
+          </div>
         </div>
-        <div
-          className="container-children"
-        >
+        <img
+          className="flow-arrow"
+          src="/img/arrow-right-2x.png"
+        />
+        <div>
           <div
-            className="rc-popover-anchor-wrapper display-inline-flex "
-            style={
-              Object {
-                "WebkitFlex": "inherit",
-                "flex": "inherit",
-              }
-            }
+            className="component-container some-css-class"
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
+            <img
+              className="diff-icon"
+              src="/img/minus.svg"
+            />
             <div
-              className="rc-point-wrapper display-inline-flex"
-              style={
-                Object {
-                  "WebkitAlignItems": "center",
-                  "WebkitFlex": "auto",
-                  "WebkitFlexFlow": "column",
-                  "alignItems": "center",
-                  "flex": "auto",
-                  "flexFlow": "column",
-                }
-              }
+              className="component message-properties-transformer"
             >
+              <img
+                className="category-frame"
+                src="/img/icons/org.mule.tooling.category.transformers.large.png"
+              />
+              <img
+                className="icon"
+                src="/img/icons/Transformer-48x32.png"
+              />
               <div
-                className="component-container some-css-class"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
+                className="label"
               >
-                <img
-                  className="diff-icon"
-                  src="/img/is-not-equal-to.svg"
-                />
-                <div
-                  className="component set-payload"
-                >
-                  <img
-                    className="category-frame"
-                    src="/img/icons/org.mule.tooling.category.transformers.large.png"
-                  />
-                  <img
-                    className="icon"
-                    src="/img/icons/SetPayload-48x32.png"
-                  />
-                  <div
-                    className="label"
-                  >
-                    Set some payload
-                  </div>
-                </div>
+                Transform something
               </div>
             </div>
           </div>
-          <img
-            className="flow-arrow"
-            src="/img/arrow-right-2x.png"
-          />
+        </div>
+        <img
+          className="flow-arrow"
+          src="/img/arrow-right-2x.png"
+        />
+        <div>
           <div
-            className="rc-popover-anchor-wrapper display-inline-flex "
-            style={
-              Object {
-                "WebkitFlex": "inherit",
-                "flex": "inherit",
-              }
-            }
+            className="component-container some-css-class"
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
           >
+            <img
+              className="diff-icon"
+              src="/img/plus.svg"
+            />
             <div
-              className="rc-point-wrapper display-inline-flex"
-              style={
-                Object {
-                  "WebkitAlignItems": "center",
-                  "WebkitFlex": "auto",
-                  "WebkitFlexFlow": "column",
-                  "alignItems": "center",
-                  "flex": "auto",
-                  "flexFlow": "column",
-                }
-              }
+              className="component http:request"
             >
+              <img
+                className="category-frame"
+                src="/img/icons/org.mule.tooling.category.cloudconnectors.large.png"
+              />
+              <img
+                className="icon"
+                src="/img/icons/http_connector_50x34.png"
+              />
               <div
-                className="component-container some-css-class"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
+                className="label"
               >
-                <img
-                  className="diff-icon"
-                  src="/img/minus.svg"
-                />
-                <div
-                  className="component message-properties-transformer"
-                >
-                  <img
-                    className="category-frame"
-                    src="/img/icons/org.mule.tooling.category.transformers.large.png"
-                  />
-                  <img
-                    className="icon"
-                    src="/img/icons/Transformer-48x32.png"
-                  />
-                  <div
-                    className="label"
-                  >
-                    Transform something
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <img
-            className="flow-arrow"
-            src="/img/arrow-right-2x.png"
-          />
-          <div
-            className="rc-popover-anchor-wrapper display-inline-flex "
-            style={
-              Object {
-                "WebkitFlex": "inherit",
-                "flex": "inherit",
-              }
-            }
-          >
-            <div
-              className="rc-point-wrapper display-inline-flex"
-              style={
-                Object {
-                  "WebkitAlignItems": "center",
-                  "WebkitFlex": "auto",
-                  "WebkitFlexFlow": "column",
-                  "alignItems": "center",
-                  "flex": "auto",
-                  "flexFlow": "column",
-                }
-              }
-            >
-              <div
-                className="component-container some-css-class"
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-              >
-                <img
-                  className="diff-icon"
-                  src="/img/plus.svg"
-                />
-                <div
-                  className="component http:request"
-                >
-                  <img
-                    className="category-frame"
-                    src="/img/icons/org.mule.tooling.category.cloudconnectors.large.png"
-                  />
-                  <img
-                    className="icon"
-                    src="/img/icons/http_connector_50x34.png"
-                  />
-                  <div
-                    className="label"
-                  >
-                    Make some request
-                  </div>
-                </div>
+                Make some request
               </div>
             </div>
           </div>
@@ -320,57 +188,35 @@ exports[`when rendering a Mule container when it has children renders correctly 
 `;
 
 exports[`when rendering a Mule container when it has no children renders correctly 1`] = `
-<div
-  className="rc-popover-anchor-wrapper display-inline-flex "
-  style={
-    Object {
-      "WebkitFlex": "inherit",
-      "flex": "inherit",
-    }
-  }
->
+<div>
   <div
-    className="rc-point-wrapper display-inline-flex"
-    style={
-      Object {
-        "WebkitAlignItems": "center",
-        "WebkitFlex": "auto",
-        "WebkitFlexFlow": "column",
-        "alignItems": "center",
-        "flex": "auto",
-        "flexFlow": "column",
-      }
-    }
+    className="container mule-flow some-css-class"
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     <div
-      className="container mule-flow some-css-class"
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
+      className="container-title"
+    >
+      Do something
+    </div>
+    <div
+      className="container-inner"
     >
       <div
-        className="container-title"
+        className="icon-container"
       >
-        Do something
-      </div>
-      <div
-        className="container-inner"
-      >
-        <div
-          className="icon-container"
-        >
-          <img
-            className="category-frame"
-            src="/img/icons/org.mule.tooling.category.scopes.large.png"
-          />
-          <img
-            className="icon container-image"
-            src="/img/icons/sub-flow-48x32.png"
-          />
-        </div>
-        <div
-          className="container-children"
+        <img
+          className="category-frame"
+          src="/img/icons/org.mule.tooling.category.scopes.large.png"
+        />
+        <img
+          className="icon container-image"
+          src="/img/icons/sub-flow-48x32.png"
         />
       </div>
+      <div
+        className="container-children"
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Replaces re-com popovers with react-popper to fix up some placement issues.
Popovers now use React portals so they are always on top of everything and the react-popper library does a good job with auto positioning the tooltip.

Fixes #47, Fixes #50