### PR TITLE
build: run semantic-release on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,10 @@ workflows:
   version: 2
   build-n-deploy:
     jobs:
-      - build:
-          filters:  # required since `deploy` has tag filters AND requires `build`
-            tags:
-              only: /.*/
+      - build
       - deploy:
           requires:
             - build
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /master/


### PR DESCRIPTION
Now we use semantic-release we want it to run on the master branch, not on tags

#11