### PR TITLE
fix: fix issue with tooltip flickering

### DIFF
--- a/public/example_xml/nice-example-diff.xml
+++ b/public/example_xml/nice-example-diff.xml
@@ -57,7 +57,7 @@ payload distinctBy $.pies]]></dw:set-payload>
         </scatter-gather>
         <http:request config-ref="" path="" method="" doc:name="Start Internal Noodle Engine"/>
     </sub-flow>
-    <munit:test description="Bork Bork" name="some-test">
+    <munit:test description="Bork Bork" name="some-test-2">
         <mock:when doc:name="xxxx" messageProcessor=".*:.*">
             <mock:with-attributes>
                 <mock:with-attribute name="name" whereValue="#[matchContains('zzzyyy')]"/>

--- a/src/main/mule_preview/client/components.cljs
+++ b/src/main/mule_preview/client/components.cljs
@@ -137,7 +137,10 @@
     (fn []
       [:div {:ref #(reset! anchor-el %)}
        [:div {:class ["component-container" css-class]
-              :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
+              :on-mouse-over (m/handler-fn
+                              (when should-show-tooltip
+                                (reset! showing-atom should-show-tooltip)
+                                (.stopPropagation event)))
               :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
         (when diff-icon-url (image diff-icon-url "diff-icon" content-root))
         [:div
@@ -162,7 +165,10 @@
     (fn []
       [:div {:ref #(reset! anchor-el %)}
        [:div {:class ["container" generated-css-class css-class]
-              :on-mouse-over (m/handler-fn (reset! showing-atom should-show-tooltip))
+              :on-mouse-over (m/handler-fn
+                              (when should-show-tooltip
+                                (reset! showing-atom should-show-tooltip)
+                                (.stopPropagation event)))
               :on-mouse-out  (m/handler-fn (reset! showing-atom false))}
         [:div {:class "container-title"} description]
         [:div {:class "container-inner"}


### PR DESCRIPTION
The mouse over event bubbles up to parent elements, so even though the mouse out event fired to
close a previous tooltip, the mouse over event would bubble up and reactivate the tooltip. In the
best case this made duplicate tooltips, in the worst case it created visual glitches.

fix #20